### PR TITLE
FIX: install 시 settings.json의 statusLine 및 관련 스크립트 누락 수정

### DIFF
--- a/src/__tests__/merge-settings.test.ts
+++ b/src/__tests__/merge-settings.test.ts
@@ -133,7 +133,7 @@ describe('copy.ts mergeSettingsJson', () => {
     mergeGlobalSettings(sourceDir, destDir);
 
     const result = readJson(path.join(destDir, 'settings.json'));
-    expect(result.statusLine).toBeUndefined();
+    expect(result.statusLine).toEqual({ type: 'command', command: 'echo test' });
     expect(result.hooks.UserPromptSubmit).toHaveLength(1);
     expect(result.hooks.UserPromptSubmit[0].hooks[0].command).toBe('skill-forced.sh');
   });
@@ -274,14 +274,14 @@ describe('copy.ts mergeSettingsJson', () => {
     expect(result).toEqual(destSettings);
   });
 
-  it('should exclude statusLine from source even on fresh install', () => {
+  it('should exclude statusLine in project mode even on fresh install', () => {
     const sourceSettings = {
       statusLine: { type: 'command', command: '~/.claude/statusline-command.sh' },
       hooks: {},
     };
     writeJson(path.join(sourceDir, 'settings.json'), sourceSettings);
 
-    mergeGlobalSettings(sourceDir, destDir);
+    mergeGlobalSettings(sourceDir, destDir, { project: true });
 
     const result = readJson(path.join(destDir, 'settings.json'));
     expect(result.statusLine).toBeUndefined();

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -23,14 +23,16 @@ export interface CategorizedFiles {
 }
 
 // Files to exclude from all copies (merge-handled separately)
+// settings.json은 mergeSettingsJson()에서 별도로 병합 처리
 export const EXCLUDE_ALWAYS = [
   'settings.json',
-  'statusline-command.sh',
 ];
 
 // Files to exclude only when installing to project
+// project 모드에서는 제외되는 파일들 (global ~/.claude/ 환경 전용)
 export const EXCLUDE_FROM_PROJECT = [
   'hooks/_dedup.sh',
+  'statusline-command.sh',
 ];
 
 /**
@@ -286,7 +288,8 @@ function replaceClaudePaths(obj: Record<string, any>): Record<string, any> {
  * Merge settings.json from source into destination.
  * Hooks are merged per event key; duplicate hook entries (by deep equality) are skipped.
  * Non-hook keys are shallow-merged (source wins for new keys, dest preserved for existing).
- * statusLine is always excluded from merge (personal environment setting).
+ * statusLine is excluded only in project mode; in global mode, source statusLine is copied
+ * if dest does not have one (preserving user customization).
  * When project=true, ~/.claude/ paths in command fields are converted to .claude/.
  */
 export function mergeSettingsJson(
@@ -326,8 +329,11 @@ export function mergeSettingsJson(
 
   // Merge top-level keys (source fills in missing keys, dest's existing keys preserved)
   for (const key of Object.keys(sourceSettings)) {
-    if (key === 'hooks' || key === 'statusLine') {
-      continue; // hooks are merged separately below; statusLine is excluded
+    if (key === 'hooks') {
+      continue; // hooks are merged separately below
+    }
+    if (key === 'statusLine' && options?.project) {
+      continue; // statusLine is excluded in project mode (personal env setting)
     }
     if (!(key in destSettings)) {
       destSettings[key] = sourceSettings[key];

--- a/src/update.ts
+++ b/src/update.ts
@@ -268,9 +268,11 @@ export async function updateClaudeFiles(options: UpdateOptions = {}): Promise<vo
   }));
 
   // Check for removed-upstream files (in metadata but not in new template)
+  // Files excluded by project mode should NOT be marked as removed-upstream
   if (metadata) {
     for (const file of Object.keys(metadata.files)) {
-      if (!files.includes(file) && !EXCLUDE_ALWAYS.includes(file)) {
+      const excludedByProject = project && EXCLUDE_FROM_PROJECT.includes(file);
+      if (!files.includes(file) && !EXCLUDE_ALWAYS.includes(file) && !excludedByProject) {
         fileStatuses.push({ file, status: 'removed-upstream' });
       }
     }


### PR DESCRIPTION
## Summary

- `templates/global/settings.json`의 `statusLine` 키와 `templates/global/statusline-command.sh`가 install 시 누락되던 버그 수정
- Global 모드에서는 둘 다 정상 설치되고, Project 모드에서는 기존처럼 제외
- 사용자 기존 `statusLine` 커스텀은 보존 (hooks merge와 동일한 dest-우선 패턴)

## 변경 내용

### `src/copy.ts`
- `statusline-command.sh`를 `EXCLUDE_ALWAYS` → `EXCLUDE_FROM_PROJECT`로 이동
- `mergeSettingsJson`에서 `statusLine` skip 조건을 "항상 skip" → "project 모드일 때만 skip"으로 변경
- 관련 JSDoc 갱신

### `src/update.ts`
- `removed-upstream` 검출 시 project 모드 + `EXCLUDE_FROM_PROJECT` 파일은 false-positive 방지

### `src/__tests__/merge-settings.test.ts`
- fresh global install에서 statusLine 복사되는지 검증
- project 모드에서 statusLine 제외되는지 검증

## 검증

- [x] `yarn build` PASS
- [x] `yarn test` 50 tests PASS
- [x] 수동 회귀 (HOME=tmp 시뮬레이션 global/project) PASS
- [x] 실제 `~/.claude/`에 적용 → statusLine 추가, 기존 env/permissions/hooks 보존, 재실행 시 멱등성 확인